### PR TITLE
Added infobox disabling

### DIFF
--- a/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
@@ -1,9 +1,6 @@
 package com.geel.hunterrumours;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.*;
 
 import java.awt.*;
 
@@ -128,6 +125,29 @@ public interface HunterRumoursConfig extends Config {
     )
     default boolean showCatchesRemainingUntilPity() {
         return true;
+    }
+
+    @ConfigItem(
+            position = 2,
+            keyName = "infoBoxDisableTimer",
+            name = "Info Box Disable Timer (minutes)",
+            description = "Disables the info box after a certain amount of time (in minutes) of no hunter rumour related activity.",
+            section = infoBoxSection
+    )
+    @Range(min = 1)
+    default int infoBoxDisableTimer() {
+        return 5;
+    }
+
+    @ConfigItem(
+            position = 3,
+            keyName = "forceShowInfoBox",
+            name = "Force Show Info Box",
+            description = "Forces the infobox to be shown even after the time set above",
+            section = infoBoxSection
+    )
+    default boolean forceShowInfoBox() {
+        return false;
     }
 
     @ConfigItem(

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -813,7 +813,7 @@ public class HunterRumoursPlugin extends Plugin {
     }
 
     /**
-     *
+     * Records the current tick as the "latest interaction time" -- used to track how long it's been since the player has engaged in Hunter Rumour-related behavior
      */
     private void updateLatestInteractionTime() {
         latestInteractionTime = client.getTickCount();


### PR DESCRIPTION
Now shows the first x (set in config) minutes after logging in, then gets removed if no interaction has happened for the x minutes set in config (later referred to as "enabled" login behavior). 
If there has been an interaction, we update the latest interaction time (tick). Then the process starts over, where the infobox gets disabled if no interaction has happened. 
I also added a force show info box boolean to give people some extra control.

The only thing we might want to (that comes to mind right now) is the login behavior. 
Maybe we could add 3 different modes:
- disabled (which would simply never enable the infobox until a rumour related action took place)
- enabled (which would have the behavior we have right now)
- forced (which would keep the infobox in a 'force shown' state until a rumour related action took place)

Where my personally preferred default would probably be either "enabled" or "disabled".

Closes https://github.com/geel9/runelite-hunter-rumours/issues/30