### PR TITLE
Stop showing locations based on interaction time & infobox disabling fixes

### DIFF
--- a/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
@@ -10,42 +10,42 @@ public interface HunterRumoursConfig extends Config {
 
     @ConfigSection(
             name = "Hunter Guild Display",
-            description = "Configure the panel that displays information while underground in the Hunter Guild",
+            description = "Configure the panel that displays information while underground in the Hunter Guild.",
             position = 0
     )
     String hunterGuildDisplaySection = "hunterGuildDisplaySection";
 
     @ConfigSection(
             name = "Current Rumour Infobox",
-            description = "Configure the infobox that shows your current Rumour",
+            description = "Configure the infobox that shows your current Rumour.",
             position = 1
     )
     String infoBoxSection = "infoBoxSection";
 
     @ConfigSection(
             name = "World Map",
-            description = "Configure the hunter creature locations the plugin adds to the world map",
+            description = "Configure the hunter creature locations the plugin adds to the world map.",
             position = 2
     )
     String worldMapSection = "worldMapSection";
 
     @ConfigSection(
             name = "Chat Messages",
-            description = "Configure various chat messages that the plugin creates",
+            description = "Configure various chat messages that the plugin creates.",
             position = 3
     )
     String messagesSection = "messagesSection";
 
     @ConfigSection(
             name = "Hunter Tiers",
-            description = "The tiers of hunters that are enabled",
+            description = "The tiers of hunters that are enabled.",
             position = 4
     )
     String tiersSection = "tiersSection";
 
     @ConfigSection(
             name = "Highlights",
-            description = "Highlights for Hunters and Hunter Targets",
+            description = "Highlights for Hunters and Hunter Targets.",
             position = 5
     )
     String highlightSection = "highlightSection";
@@ -54,7 +54,7 @@ public interface HunterRumoursConfig extends Config {
             position = 0,
             keyName = "showWorldMapLocations",
             name = "Show World Map Locations",
-            description = "Whether the locations of your current rumour should show up on your world map",
+            description = "Whether the locations of your current rumour should show up on your world map.",
             section = worldMapSection
     )
     default boolean showWorldMapLocations() {
@@ -65,7 +65,7 @@ public interface HunterRumoursConfig extends Config {
             position = 1,
             keyName = "compactWorldMap",
             name = "Compact World Map Locations",
-            description = "Only show 1 icon per location on the World Map",
+            description = "Only show 1 icon per location on the World Map.",
             section = worldMapSection
     )
     default boolean compactWorldMap() {
@@ -76,7 +76,7 @@ public interface HunterRumoursConfig extends Config {
             position = 2,
             keyName = "worldMapLocationsDisableTimer",
             name = "Locations Disable Timer (minutes)",
-            description = "Stops showing the locations on the World Map after a certain amount of time (in minutes) of no hunter rumour related activity.",
+            description = "Stops showing the locations on the World Map after a certain amount of time (in minutes) of no hunter rumour related activity.<br />Turn on 'Force Show Locations' if you want the info box to be visible at all times.",
             section = worldMapSection
     )
     @Range(min = 1)
@@ -88,7 +88,7 @@ public interface HunterRumoursConfig extends Config {
             position = 3,
             keyName = "forceShowWorldMapLocations",
             name = "Force Show Locations",
-            description = "Forces the World Map Locations to be shown even after the time set above",
+            description = "Forces the World Map Locations to be shown even after the time set above.<br />Only works if 'Show World Map Locations' is enabled.",
             section = worldMapSection
     )
     default boolean forceShowWorldMapLocations() {
@@ -99,7 +99,7 @@ public interface HunterRumoursConfig extends Config {
             position = 0,
             keyName = "showOverlay",
             name = "Show Hunter Guild Info Panel",
-            description = "Show an overlay that lists the current hunter guild rumours when in the burrows",
+            description = "Show an overlay that lists the current hunter guild rumours when in the burrows.",
             section = hunterGuildDisplaySection
     )
     default boolean showOverlay() {
@@ -110,7 +110,7 @@ public interface HunterRumoursConfig extends Config {
             position = 1,
             keyName = "showAllHunters",
             name = "List All Hunter Rumours",
-            description = "List all tracked hunters and their current rumours in the guild overlay",
+            description = "List all tracked hunters and their current rumours in the guild overlay.",
             section = hunterGuildDisplaySection
     )
     default boolean guildOverlayListHunters() {
@@ -121,7 +121,7 @@ public interface HunterRumoursConfig extends Config {
             position = 2,
             keyName = "showBackToBackState",
             name = "Show Back-to-Back State",
-            description = "Displays the back-to-back state (enabled/disabled) in the guild overlay",
+            description = "Displays the back-to-back state (enabled/disabled) in the guild overlay.",
             section = hunterGuildDisplaySection
     )
     default boolean guildOverlayShowBackToBackState() {
@@ -132,7 +132,7 @@ public interface HunterRumoursConfig extends Config {
             position = 0,
             keyName = "showRumourInfoBox",
             name = "Show Rumour Infobox",
-            description = "Whether an infobox containing your current rumour target should be displayed",
+            description = "Whether an infobox containing your current rumour target should be displayed.",
             section = infoBoxSection
     )
     default boolean showInfoBox() {
@@ -143,7 +143,7 @@ public interface HunterRumoursConfig extends Config {
             position = 1,
             keyName = "showCatchesRemainingUntilPity",
             name = "Show Catches Remaining",
-            description = "Show the catches remaining until the pity threshold is reached",
+            description = "Show the catches remaining until the pity threshold is reached.",
             section = infoBoxSection
     )
     default boolean showCatchesRemainingUntilPity() {
@@ -154,7 +154,7 @@ public interface HunterRumoursConfig extends Config {
             position = 2,
             keyName = "infoBoxDisableTimer",
             name = "Info Box Disable Timer (minutes)",
-            description = "Disables the info box after a certain amount of time (in minutes) of no hunter rumour related activity.",
+            description = "Disables the info box after a certain amount of time (in minutes) of no hunter rumour related activity.<br />Turn on 'Force Show Info Box' if you want the info box to be visible at all times.",
             section = infoBoxSection
     )
     @Range(min = 1)
@@ -166,7 +166,7 @@ public interface HunterRumoursConfig extends Config {
             position = 3,
             keyName = "forceShowInfoBox",
             name = "Force Show Info Box",
-            description = "Forces the infobox to be shown even after the time set above",
+            description = "Forces the infobox to be shown even after the time set above<br />Only works if 'Show Rumour Infobox' is enabled.",
             section = infoBoxSection
     )
     default boolean forceShowInfoBox() {
@@ -177,7 +177,7 @@ public interface HunterRumoursConfig extends Config {
             position = 0,
             keyName = "currentRumourMessage",
             name = "Current Rumour Message",
-            description = "Place a message in chat whenever the current Rumour changes",
+            description = "Place a message in chat whenever the current Rumour changes.",
             section = messagesSection
     )
     default boolean currentRumourMessage() {
@@ -188,7 +188,7 @@ public interface HunterRumoursConfig extends Config {
             position = 1,
             keyName = "backToBackMessage",
             name = "Back-To-Back Message",
-            description = "Place a message in chat whenever the current back-to-back status changes",
+            description = "Place a message in chat whenever the current back-to-back status changes.",
             section = messagesSection
     )
     default boolean backToBackMessage() {
@@ -210,7 +210,7 @@ public interface HunterRumoursConfig extends Config {
             position = 0,
             keyName = "includeMasterHunters",
             name = "Include Master Hunters",
-            description = "Include master hunters in highlighting and info reports",
+            description = "Include master hunters in highlighting and info reports.",
             section = tiersSection
     )
     default boolean includeMasterHunters() {
@@ -221,7 +221,7 @@ public interface HunterRumoursConfig extends Config {
             position = 1,
             keyName = "includeExpertHunters",
             name = "Include Expert Hunters",
-            description = "Include Expert hunters in highlighting and info reports",
+            description = "Include Expert hunters in highlighting and info reports.",
             section = tiersSection
     )
     default boolean includeExpertHunters() {
@@ -232,7 +232,7 @@ public interface HunterRumoursConfig extends Config {
             position = 2,
             keyName = "includeAdeptHunters",
             name = "Include Adept Hunters",
-            description = "Include adept hunters in highlighting and info reports",
+            description = "Include adept hunters in highlighting and info reports.",
             section = tiersSection
     )
     default boolean includeAdeptHunters() {
@@ -243,7 +243,7 @@ public interface HunterRumoursConfig extends Config {
             position = 3,
             keyName = "includeNoviceHunters",
             name = "Include Novice Hunters",
-            description = "Include novice hunters in highlighting and info reports",
+            description = "Include novice hunters in highlighting and info reports.",
             section = tiersSection
     )
     default boolean includeNoviceHunters() {
@@ -254,7 +254,7 @@ public interface HunterRumoursConfig extends Config {
             position = 0,
             keyName = "highlightCurrentHunter",
             name = "Highlight current hunter",
-            description = "Whether the hunter that assigned your current task should be highlighted",
+            description = "Whether the hunter that assigned your current task should be highlighted.",
             section = highlightSection
     )
     default boolean highlightCurrentHunter() {
@@ -265,7 +265,7 @@ public interface HunterRumoursConfig extends Config {
             position = 1,
             keyName = "highlightKnownHunters",
             name = "Highlight known hunters",
-            description = "Whether hunters whose rumour is known should be highlighted",
+            description = "Whether hunters whose rumour is known should be highlighted.",
             section = highlightSection
     )
     default boolean highlightKnownHunters() {
@@ -276,7 +276,7 @@ public interface HunterRumoursConfig extends Config {
             position = 2,
             keyName = "highlightUnknownHunters",
             name = "Highlight unknown hunters",
-            description = "Whether hunters whose rumour is known should be highlighted",
+            description = "Whether hunters whose rumour is known should be highlighted.",
             section = highlightSection
     )
     default boolean highlightUnknownHunters() {
@@ -287,7 +287,7 @@ public interface HunterRumoursConfig extends Config {
             position = 3,
             keyName = "highlightHunterNPCs",
             name = "Highlight Hunter NPCs",
-            description = "Whether your current rumour target should be highlighted",
+            description = "Whether your current rumour target should be highlighted.",
             section = highlightSection
     )
     default boolean highlightHunterNPCs() {
@@ -298,7 +298,7 @@ public interface HunterRumoursConfig extends Config {
             position = 4,
             keyName = "currentHunterHighlightColor",
             name = "Current hunter highlight color",
-            description = "Highlight color for hunter who assigned your current rumour",
+            description = "Highlight color for hunter who assigned your current rumour.",
             section = highlightSection
     )
     default Color currentHunterHighlightColor() {
@@ -310,7 +310,7 @@ public interface HunterRumoursConfig extends Config {
             position = 5,
             keyName = "knownHunterHighlightColor",
             name = "Known hunter highlight color",
-            description = "Highlight color for hunters whose rumours are known",
+            description = "Highlight color for hunters whose rumours are known.",
             section = highlightSection
     )
     default Color knownHunterHighlightColor() {
@@ -321,7 +321,7 @@ public interface HunterRumoursConfig extends Config {
             position = 6,
             keyName = "unknownHunterHighlightColor",
             name = "Unknown hunter highlight color",
-            description = "Highlight color for hunters whose rumours are not known",
+            description = "Highlight color for hunters whose rumours are not known.",
             section = highlightSection
     )
     default Color unknownHunterHighlightColor() {
@@ -333,7 +333,7 @@ public interface HunterRumoursConfig extends Config {
             position = 7,
             keyName = "hunterNPCHighlightColor",
             name = "Hunter NPC Highlight Color",
-            description = "Highlight color for Hunter targets",
+            description = "Highlight color for Hunter targets.",
             section = highlightSection
     )
     default Color hunterNPCHighlightColor() {

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
@@ -1,9 +1,6 @@
 package com.geel.hunterrumours;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.*;
 
 import java.awt.*;
 
@@ -128,6 +125,29 @@ public interface HunterRumoursConfig extends Config {
     )
     default boolean showCatchesRemainingUntilPity() {
         return true;
+    }
+
+    @ConfigItem(
+            position = 2,
+            keyName = "infoBoxDisableTimer",
+            name = "Info Box Disable Timer (minutes)",
+            description = "Disables the info box after a certain amount of time (in minutes) of no hunter rumour related activity.",
+            section = infoBoxSection
+    )
+    @Range(min = 1)
+    default int infoBoxDisableTimer() {
+        return 5;
+    }
+
+    @ConfigItem(
+            position = 3,
+            keyName = "forceShowInfoBox",
+            name = "Force Show Info Box",
+            description = "Forces the infobox to be shown even after the time set above",
+            section = infoBoxSection
+    )
+    default boolean forceShowInfoBox() {
+        return false;
     }
 
     @ConfigItem(

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
@@ -73,6 +73,29 @@ public interface HunterRumoursConfig extends Config {
     }
 
     @ConfigItem(
+            position = 2,
+            keyName = "worldMapLocationsDisableTimer",
+            name = "Locations Disable Timer (minutes)",
+            description = "Stops showing the locations on the World Map after a certain amount of time (in minutes) of no hunter rumour related activity.",
+            section = worldMapSection
+    )
+    @Range(min = 1)
+    default int worldMapLocationsDisableTimer() {
+        return 5;
+    }
+
+    @ConfigItem(
+            position = 3,
+            keyName = "forceShowWorldMapLocations",
+            name = "Force Show Locations",
+            description = "Forces the World Map Locations to be shown even after the time set above",
+            section = worldMapSection
+    )
+    default boolean forceShowWorldMapLocations() {
+        return false;
+    }
+
+    @ConfigItem(
             position = 0,
             keyName = "showOverlay",
             name = "Show Hunter Guild Info Panel",

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -304,6 +304,15 @@ public class HunterRumoursPlugin extends Plugin {
             }
         }
 
+        if (currentTick - latestInteractionTime > config.worldMapLocationsDisableTimer() * 100) {
+            if (!config.forceShowWorldMapLocations()) {
+                for (HunterRumourWorldMapPoint location : currentMapPoints) {
+                    worldMapPointManager.remove(location);
+                }
+                currentMapPoints.clear();
+            }
+        }
+
         if (!isShowingInfoBox) {
             infoBoxManager.addInfoBox(infoBox);
         }

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -183,7 +183,7 @@ public class HunterRumoursPlugin extends Plugin {
         if (items != hunterKitItems) {
             hunterKitItems = items;
             if (items > 0) {
-                updateLatestInteractionTime(); 
+                updateLatestInteractionTime();
             }
             refreshAllDisplays();
         }
@@ -296,27 +296,16 @@ public class HunterRumoursPlugin extends Plugin {
             return;
         }
 
-        if (currentTick - latestInteractionTime > config.infoBoxDisableTimer() * 100) {
-            if (!config.forceShowInfoBox()) {
-                infoBoxManager.removeInfoBox(infoBox);
-                isShowingInfoBox = false;
-                return;
+        if (shouldInfoBoxBeDisabled()) {
+            infoBoxManager.removeInfoBox(infoBox);
+            isShowingInfoBox = false;
+        }
+        if (shouldWorldMapLocationsBeDisabled()) {
+            for (HunterRumourWorldMapPoint location : currentMapPoints) {
+                worldMapPointManager.remove(location);
             }
+            currentMapPoints.clear();
         }
-
-        if (currentTick - latestInteractionTime > config.worldMapLocationsDisableTimer() * 100) {
-            if (!config.forceShowWorldMapLocations()) {
-                for (HunterRumourWorldMapPoint location : currentMapPoints) {
-                    worldMapPointManager.remove(location);
-                }
-                currentMapPoints.clear();
-            }
-        }
-
-        if (!isShowingInfoBox) {
-            infoBoxManager.addInfoBox(infoBox);
-        }
-        isShowingInfoBox = true;
     }
 
     /**
@@ -612,8 +601,8 @@ public class HunterRumoursPlugin extends Plugin {
 
         // Determine if it's a "rumour complete" message
         if (actualMessage.contains("would you like another rumour?") ||
-            actualMessage.contains("here's your reward.") ||
-            actualMessage.contains("another one done?")) {
+                actualMessage.contains("here's your reward.") ||
+                actualMessage.contains("another one done?")) {
             setHunterRumour(currentHunter, Rumour.NONE);
             setHunterRumourState(false);
             setCaughtCreatures(0);
@@ -676,7 +665,7 @@ public class HunterRumoursPlugin extends Plugin {
             isShowingInfoBox = false;
         }
 
-        if (!config.showInfoBox()) {
+        if (shouldInfoBoxBeDisabled()) {
             return;
         }
 
@@ -699,7 +688,7 @@ public class HunterRumoursPlugin extends Plugin {
         }
         currentMapPoints.clear();
 
-        if (!config.showWorldMapLocations()) {
+        if (shouldWorldMapLocationsBeDisabled()) {
             return;
         }
 
@@ -828,6 +817,38 @@ public class HunterRumoursPlugin extends Plugin {
      */
     private void updateLatestInteractionTime() {
         latestInteractionTime = client.getTickCount();
+    }
+
+    /**
+     * Checks the configurations of the info box, returns true if the info box should be disabled.
+     */
+    private boolean shouldInfoBoxBeDisabled() {
+        if (!config.showInfoBox()) {
+            return true;
+        }
+
+        if (client.getTickCount() - latestInteractionTime > config.infoBoxDisableTimer() * 100) {
+            if (!config.forceShowInfoBox()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks the configurations of the world map locations, returns true if the world map locations should be disabled.
+     */
+    private boolean shouldWorldMapLocationsBeDisabled() {
+        if (!config.showWorldMapLocations()) {
+            return true;
+        }
+
+        if (client.getTickCount() - latestInteractionTime > config.worldMapLocationsDisableTimer() * 100) {
+            if (!config.forceShowWorldMapLocations()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -292,10 +292,6 @@ public class HunterRumoursPlugin extends Plugin {
     public void onGameTick(GameTick event) {
         final int currentTick = client.getTickCount();
 
-        if (!config.showInfoBox()) {
-            return;
-        }
-
         if (shouldInfoBoxBeDisabled()) {
             infoBoxManager.removeInfoBox(infoBox);
             isShowingInfoBox = false;

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -813,7 +813,7 @@ public class HunterRumoursPlugin extends Plugin {
     }
 
     /**
-     *
+     * Records the current tick as the "latest interaction time" -- used to track how long it's been since the player has engaged in Hunter Rumour-related behavior
      */
     private void updateLatestInteractionTime() {
         latestInteractionTime = client.getTickCount();


### PR DESCRIPTION
Adds world map location hiding and fixes issues related to infobox disabling not working.
Refactored a few hiding related things (currenttime + timer checks) to be in functions so we can reuse it in the refreshAllDisplays function.
Stopped flickering of locations / infobox if you toggle some of the settings.