### PR TITLE
Fix resetting pity rate kc when doing novice contracts

### DIFF
--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -570,7 +570,8 @@ public class HunterRumoursPlugin extends Plugin {
 
         // Determine if it's a "rumour complete" message
         if (actualMessage.contains("would you like another rumour?") ||
-            actualMessage.contains("here's your reward.")) {
+            actualMessage.contains("here's your reward.") ||
+            actualMessage.contains("Another one done?") {
             setHunterRumour(currentHunter, Rumour.NONE);
             setHunterRumourState(false);
             setCaughtCreatures(0);

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -571,7 +571,7 @@ public class HunterRumoursPlugin extends Plugin {
         // Determine if it's a "rumour complete" message
         if (actualMessage.contains("would you like another rumour?") ||
             actualMessage.contains("here's your reward.") ||
-            actualMessage.contains("Another one done?") {
+            actualMessage.contains("another one done?")) {
             setHunterRumour(currentHunter, Rumour.NONE);
             setHunterRumourState(false);
             setCaughtCreatures(0);


### PR DESCRIPTION
Add a "rumour complete" catch for Huntmaster Gilman (Novice) based on his dialog to reset the rumour displays.
![Screenshot 2024-05-26 054045](https://github.com/geel9/runelite-hunter-rumours/assets/13482853/e57084fd-c2e3-4662-9157-79d633e9d123)
