### PR TITLE
Correct the description of the "highlight unknown hunters" setting

### DIFF
--- a/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
@@ -371,7 +371,7 @@ public interface HunterRumoursConfig extends Config {
             position = 2,
             keyName = "highlightUnknownHunters",
             name = "Highlight unknown hunters",
-            description = "Whether hunters whose rumour is known should be highlighted.",
+            description = "Whether hunters whose rumour is unknown should be highlighted.",
             section = highlightSection
     )
     default boolean highlightUnknownHunters() {


### PR DESCRIPTION
The "highlight unknown hunters" setting currently has the same description as "highlight known hunters". This PR changes the word "known" to "unknown" in the description to fix that.