### PR TITLE
Recommend Necropolis over Uzer for Orange Salamanders

### DIFF
--- a/src/main/java/com/geel/hunterrumours/RumourInfoBox.java
+++ b/src/main/java/com/geel/hunterrumours/RumourInfoBox.java
@@ -9,6 +9,7 @@ import net.runelite.client.util.ColorUtil;
 
 import javax.annotation.Nonnull;
 import java.awt.*;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -19,18 +20,17 @@ public class RumourInfoBox extends InfoBox {
         super(itemManager.getImage(rumour.getTargetCreature().getItemId()), plugin);
         this.plugin = plugin;
 
-        final Map<String, List<RumourLocation>> locations = RumourLocation.getGroupedLocationsForRumour(rumour);
+        final var locations = RumourLocation.getGroupedLocationsForRumour(rumour);
         final StringBuilder sb = new StringBuilder();
 
-        locations.keySet().forEach(locationName -> {
-            var keyedLocations = locations.get(locationName);
-            RumourLocation rumourLocation = keyedLocations.get(0);
+        locations.forEach(entry -> {
+            RumourLocation rumourLocation = entry.getValue().get(0);
 
-            sb.append("</br>  • ").append(locationName).append(" (");
+            sb.append("</br>  • ").append(entry.getKey()).append(" (");
             if (!rumourLocation.getFairyRingCode().equals("")) {
                 sb.append(rumourLocation.getFairyRingCode()).append(", ");
             }
-            sb.append(keyedLocations.size()).append(" spawns)");
+            sb.append(entry.getValue().size()).append(" spawns)");
         });
 
         final Trap trap = rumour.getTargetCreature().getTrap();

--- a/src/main/java/com/geel/hunterrumours/enums/RumourLocation.java
+++ b/src/main/java/com/geel/hunterrumours/enums/RumourLocation.java
@@ -1,10 +1,8 @@
 package com.geel.hunterrumours.enums;
 
 import static com.geel.hunterrumours.enums.Rumour.*;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -406,15 +404,34 @@ public enum RumourLocation
 	 */
 	public static Set<RumourLocation> getCollapsedLocationsForRumour(Rumour rumour) {
 		var groupedLocations = getGroupedLocationsForRumour(rumour);
-		return groupedLocations.keySet().stream().map(l -> groupedLocations.get(l).get(0)).collect(Collectors.toSet());
+		return groupedLocations.map(l -> l.getValue().get(0)).collect(Collectors.toSet());
 	}
 
 	/**
 	 * Gets all RumourLocations linked to the given Rumour, grouped by LocationName
 	 */
-	public static Map<String, List<RumourLocation>> getGroupedLocationsForRumour(Rumour rumour)
+	public static Stream<Map.Entry<String, List<RumourLocation>>> getGroupedLocationsForRumour(Rumour rumour)
 	{
-		return getLocationsStreamForRumour(rumour).collect(Collectors.groupingBy(RumourLocation::getLocationName));
+		var locations = getLocationsStreamForRumour(rumour).toArray(RumourLocation[]::new);
+
+		// Create a map to remember the ordering of declaration of the locations (by the first instance of
+		// each location name). This is so we can group by name (which loses this ordering) and then sort the groups
+		// by the original declaration order.
+		Map<String, Integer> locationDeclarationOrder = new HashMap<>();
+		int i = 0;
+		for(RumourLocation location : locations) {
+			if(!locationDeclarationOrder.containsKey(location.getLocationName())) {
+				locationDeclarationOrder.put(location.getLocationName(), i++);
+			}
+		}
+
+		// I do not know Java very well and there is surely a better way to do this, but... I think it works, so, oh well.
+		// Group the locations by their name, then return those groups sorted by declaration order of their first location.
+		 return Arrays.stream(locations)
+				 .collect(Collectors.groupingBy(RumourLocation::getLocationName))
+				 .entrySet()
+				 .stream()
+				 .sorted(Comparator.comparingInt(a -> locationDeclarationOrder.get(a.getKey())));
 	}
 
 	private static Stream<RumourLocation> getLocationsStreamForRumour(Rumour rumour)


### PR DESCRIPTION
- Adds more locations to the Necropolis hunter area for Orange Salamanders
	- Would like to look into changing how we do this -- we are very inaccurate right now in terms of how many creatures are actually at each spawn location
		- Additionally, the relevant factor (for salamanders at least) is how many _trees_ there are, not _spawns_
		- Oh well, that's for another day
- Places Necropolis before Uzer to push players there, as it's a better spot
- Changes name of location from `Necropolis Hunter Area` to `Necropolis (w/ Beneath Cursed Sands)`
- Changes `RumourLocation.getGroupedLocationsForRumour` to return an ordered stream of locations based on their declaration order in the enum

Resolves #52 