### PR TITLE
Rework infobox display logic

### DIFF
--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -849,7 +849,7 @@ public class HunterRumoursPlugin extends Plugin {
         }
 
         // Infobox should be disabled if it's been long enough since the last interaction time
-        return client.getTickCount() - latestInteractionTime <= config.infoBoxDisableTimer();
+        return client.getTickCount() - latestInteractionTime <= config.infoBoxDisableTimer() * 100;
     }
 
     /**


### PR DESCRIPTION
- Attempts to rework the logic behind whether the infobox should be shown or not to fix jankiness
	- Infobox should no longer be "stuck on" or refuse to appear
		- The major reason it would be stuck on is that we would update the "last interaction time" whenever the game state changed to `LOGGED_IN`
			- Logging in doesn't mean you are interacting with hunter rumours
			- The game state "changes" to `LOGGED_IN` whenever a new map area is loaded, almost guaranteeing the infobox would _always_ be shown