### PR TITLE
Change default hunter creature highlight color

### DIFF
--- a/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
@@ -443,6 +443,6 @@ public interface HunterRumoursConfig extends Config {
     )
     default Color hunterNPCHighlightColor() {
 
-        return new Color(0x2A, 0xBE, 0x2A);
+        return new Color(0x4B, 0x9D, 0xDD);
     }
 }


### PR DESCRIPTION
- Changes default hunter creature highlight color from a bright green to a pale blue
	- Most hunter creatures are in a green area, so the highlight blends in with the background