### PR TITLE
Add Fairy Ring Configuration Section with Configurable Timer and Force Option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'com.geel.hunterrumours'
-version = '1.3.4'
+version = '1.3.3'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'com.geel.hunterrumours'
-version = '1.3.3'
+version = '1.3.4'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
@@ -30,23 +30,30 @@ public interface HunterRumoursConfig extends Config {
     String worldMapSection = "worldMapSection";
 
     @ConfigSection(
+            name = "Fairy Rings",
+            description = "Configure the behavior of fairy rings while you have a rumour",
+            position = 4
+    )
+    String fairyRingSection = "fairyRingSection";
+
+    @ConfigSection(
             name = "Chat Messages",
             description = "Configure various chat messages that the plugin creates.",
-            position = 4
+            position = 5
     )
     String messagesSection = "messagesSection";
 
     @ConfigSection(
             name = "Hunter Tiers",
             description = "The tiers of hunters that are enabled.",
-            position = 5
+            position = 6
     )
     String tiersSection = "tiersSection";
 
     @ConfigSection(
             name = "Highlights",
             description = "Highlights for Hunters and Hunter Targets.",
-            position = 6
+            position = 7
     )
     String highlightSection = "highlightSection";
 
@@ -54,10 +61,34 @@ public interface HunterRumoursConfig extends Config {
             position = 0,
             keyName = "autoJumpFairyRing",
             name = "Auto-Scroll to Fairy Ring",
-            description = "Whether to automatically scroll to the appropriate fairy ring for your current rumour when opening the fairy ring interface"
+            description = "Whether to automatically scroll to the appropriate fairy ring for your current rumour when opening the fairy ring interface",
+            section = fairyRingSection
     )
     default boolean autoJumpFairyring() {
         return true;
+    }
+
+    @ConfigItem(
+            position = 1,
+            keyName = "autoJumpFairyRingDisableTimer",
+            name = "Auto-Scroll Disable Timer (minutes)",
+            description = "Stops auto-scrolling the fairy ring menu after a certain amount of time (in minutes) of no hunter rumour related activity.<br />Turn on 'Force Auto-Scroll Fairy Ring' if you want the fairy ring menu to auto-scroll at all times.",
+            section = fairyRingSection
+    )
+    @Range(min = 1)
+    default int autoJumpFairyRingDisableTimer() {
+        return 5;
+    }
+
+    @ConfigItem(
+            position = 2,
+            keyName = "forceAutoJumpFairyRing",
+            name = "Force Auto-Scroll to Fairy Ring",
+            description = "Forces the fairy ring interface to scroll to the appropriate fairy ring for your current rumour even after the time set above.<br />Only works if 'Auto-Scroll to Fairy Ring' is enabled.",
+            section = fairyRingSection
+    )
+    default boolean forceAutoJumpFairyRing() {
+        return false;
     }
 
     @ConfigItem(

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -1037,7 +1037,7 @@ public class HunterRumoursPlugin extends Plugin {
     }
 
     /**
-     * Checks the configurations of the world map locations, returns true if the world map locations should be disabled.
+     * Checks the configurations of the world map locations, returns true if the world map locations should be enabled.
      */
     private boolean shouldWorldMapLocationsBeShown() {
         // If world map locations aren't enabled, obviously they should not be enabled!

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -482,8 +482,7 @@ public class HunterRumoursPlugin extends Plugin {
 
         var fairyRingCode = firstLocationWithFairyRing.get().getValue().get(0).getFairyRingCode();
 
-        // If we haven't interacted with hunter rumours in the last 2 minutes, bail out
-        if (!interactedRecently(200)) {
+        if (!shouldFairyRingAutoJump()) {
             return;
         }
 
@@ -1053,6 +1052,24 @@ public class HunterRumoursPlugin extends Plugin {
 
         // World map locations should be disabled if it's been long enough since the last interaction time
         return interactedRecently(config.worldMapLocationsDisableTimer() * 100);
+    }
+
+    /**
+     * Checks the configurations for auto-scrolling the fairy ring interface, returns true if the fairy ring interface should auto-scroll.
+     */
+    private boolean shouldFairyRingAutoJump() {
+        // If auto jump isn't enabled, obviously it should not be enabled!
+        if (!config.autoJumpFairyring()) {
+            return false;
+        }
+
+        // If "force auto-scroll to fairy ring" is enabled, then we should never disable auto-scroll.
+        if (config.forceAutoJumpFairyRing()) {
+            return true;
+        }
+
+        // Fairy ring auto-scroll should be disabled if it's been long enough since the last interaction time
+        return interactedRecently(config.autoJumpFairyRingDisableTimer() * 100);
     }
 
     /**


### PR DESCRIPTION
While using this plugin I was curious why it seemed like the fairy ring scroll only worked sometimes.

It was due to a non-configurable 2-minute timeout on the auto-scroll function.

In this PR I added a new configuration section for fairy rings and slotted in a timer and force option, very similar to how world map locations are handled currently.