### PR TITLE
Stop Tracking Caught Creatures Once Rumour Is Complete

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'com.geel.hunterrumours'
-version = '1.3.3'
+version = '1.3.4'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -254,8 +254,10 @@ public class HunterRumoursPlugin extends Plugin {
 
         // Find the creature that corresponds to the XP drop and mark them as being fucking dead
         if (Arrays.stream(getCurrentRumour().getTargetCreature().getPossibleXpDrops()).anyMatch(possibleXpDrop -> possibleXpDrop == finalXpDiff)) {
-            incrementCaughtCreatures();
-            refreshAllDisplays();
+            if (!currentRumourFinished) {
+                incrementCaughtCreatures();
+                refreshAllDisplays();
+            }
         }
 
         previousHunterExp = currentXp;


### PR DESCRIPTION
This PR resolves #73 by adding a check for the rumour's completion status before incrementing the caught creatures counter.