### PR TITLE
Additional Highlight Options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'com.geel.hunterrumours'
-version = '1.3.3'
+version = '1.3.4'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
@@ -8,6 +8,13 @@ import java.awt.*;
 public interface HunterRumoursConfig extends Config {
     String GROUP = "hunterrumours";
 
+    enum HighlightType {
+        OUTLINE,
+        TILE,
+        BOTH,
+        NONE
+    }
+
     @ConfigSection(
             name = "Hunter Guild Display",
             description = "Configure the panel that displays information while underground in the Hunter Guild.",
@@ -395,8 +402,8 @@ public interface HunterRumoursConfig extends Config {
             description = "Whether your current rumour target should be highlighted.",
             section = highlightSection
     )
-    default boolean highlightHunterNPCs() {
-        return true;
+    default HighlightType highlightHunterNPCs() {
+        return HighlightType.OUTLINE;
     }
 
     @ConfigItem(

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -933,7 +933,7 @@ public class HunterRumoursPlugin extends Plugin {
         }
 
         // Highlight Rumour Target (hunter creature) if relevant
-        if (config.highlightHunterNPCs()) {
+        if (config.highlightHunterNPCs() != HunterRumoursConfig.HighlightType.NONE) {
             Rumour currentRumour = getCurrentRumour();
             if (currentRumour == Rumour.NONE
                     || currentRumour.getTargetCreature().getNpcId() == 0
@@ -943,12 +943,24 @@ public class HunterRumoursPlugin extends Plugin {
                 return null;
             }
 
-            return HighlightedNpc.builder()
+            HighlightedNpc.HighlightedNpcBuilder highlightedNpcBuilder = HighlightedNpc.builder()
                     .npc(npc)
                     .highlightColor(config.hunterNPCHighlightColor())
-                    .borderWidth(2)
-                    .outline(true)
-                    .build();
+                    .borderWidth(2);
+
+            switch (config.highlightHunterNPCs()) {
+                case TILE:
+                    highlightedNpcBuilder.tile(true);
+                    break;
+                case OUTLINE:
+                    highlightedNpcBuilder.outline(true);
+                    break;
+                case BOTH:
+                    highlightedNpcBuilder.tile(true);
+                    highlightedNpcBuilder.outline(true);
+            }
+
+            return highlightedNpcBuilder.build();
         }
 
         return null;


### PR DESCRIPTION
This PR Resolves #72 by replacing the current checkbox for "Highlight Hunter NPCs" with a dropdown with the following options:
Outline
Tile
Both
None

Outline is selected by default to replicate current default behavior.
Images with resulting highlights attached.
<img width="494" height="323" alt="config-outline" src="https://github.com/user-attachments/assets/ccf1d1f7-2597-41b9-94f0-6a7420af1744" />
<img width="513" height="417" alt="config-tile" src="https://github.com/user-attachments/assets/6d96c920-ca04-4bc1-9407-d00c5da89498" />
<img width="534" height="388" alt="config-both" src="https://github.com/user-attachments/assets/4561ed41-3108-452b-90f3-48bbd53ee268" />
<img width="578" height="475" alt="config-none" src="https://github.com/user-attachments/assets/05a28f99-360b-48f7-8f55-27b1a18b8b27" />



