### PR TITLE
Add notification on rumour rare part drop

### DIFF
--- a/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
@@ -498,6 +498,8 @@ public interface HunterRumoursConfig extends Config {
             description = "Send a notification when you receive the rare piece that completes a rumour.",
             section = notificationSection
     )
-    default Notification notificationOnRumourDrop() { return Notification.OFF; }
+    default Notification notificationOnRumourDrop() {
 
+        return Notification.OFF;
+    }
 }

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursConfig.java
@@ -64,6 +64,13 @@ public interface HunterRumoursConfig extends Config {
     )
     String highlightSection = "highlightSection";
 
+    @ConfigSection(
+            name = "Notification",
+            description = "Settings for notifications triggered by rumour events.",
+            position = 8
+    )
+    String notificationSection = "notificationSection";
+
     @ConfigItem(
             position = 0,
             keyName = "autoJumpFairyRing",
@@ -483,4 +490,14 @@ public interface HunterRumoursConfig extends Config {
 
         return new Color(0x4B, 0x9D, 0xDD);
     }
+
+    @ConfigItem(
+            position = 0,
+            keyName = "notificationOnRumourDrop",
+            name = "Notification on Rumour Drop",
+            description = "Send a notification when you receive the rare piece that completes a rumour.",
+            section = notificationSection
+    )
+    default Notification notificationOnRumourDrop() { return Notification.OFF; }
+
 }

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -15,7 +15,6 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneLiteConfig;
-import net.runelite.client.config.Notification;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ItemManager;

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -15,6 +15,7 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneLiteConfig;
+import net.runelite.client.config.Notification;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ItemManager;
@@ -27,6 +28,7 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
+import net.runelite.client.Notifier;
 
 import javax.inject.Inject;
 import java.awt.*;
@@ -93,6 +95,9 @@ public class HunterRumoursPlugin extends Plugin {
 
     @Inject
     private RuneLiteConfig runeLiteConfig;
+
+    @Inject
+    private Notifier notifier;
 
     @Inject
     private WorldMapPointManager worldMapPointManager;
@@ -708,6 +713,8 @@ public class HunterRumoursPlugin extends Plugin {
         if (!Text.standardize(message).equalsIgnoreCase("You find a rare piece of the creature! You should take it back to the Hunter Guild.")) {
             return;
         }
+
+        notifier.notify(config.notificationOnRumourDrop(), "Hunter Rumour completed! You found the rare piece.");
 
         if (config.endOfRumourMessage()) {
             final int caughtCreatures = getCaughtRumourCreatures();


### PR DESCRIPTION
Adds the section for notifications in settings/config and the toggle-option to get a notification when you get the rare drop of the current Rumour creature. By default it is OFF, so it doesn't change anything for existing users.

Closes #88 