### PR TITLE
Summer Sweep Up changes

### DIFF
--- a/src/main/java/com/geel/hunterrumours/enums/Trap.java
+++ b/src/main/java/com/geel/hunterrumours/enums/Trap.java
@@ -13,7 +13,7 @@ public enum Trap {
     PIT("Pit Trap", ItemID.TEASING_STICK, 30, 28),
     BOX_TRAP("Box Trap", ItemID.BOX_TRAP, 100, 94),
     FALCONRY("Falconry", ItemID.FALCONERS_GLOVE, 20, 18),
-    BUTTERFLY("Butterfly Net", ItemID.BUTTERFLY_NET, 150, 142),
+    BUTTERFLY("Butterfly Net", ItemID.BUTTERFLY_NET, 80, 76), // might be 75 with outfit instead of 76
     NOOSE("Tracking", ItemID.NOOSE_WAND, 30, 28),
     NOOSE_HERBIBOAR("Tracking", ItemID.NOOSE_WAND, 14, 12);
 


### PR DESCRIPTION
Updated the catch rate for the BUTTERFLY trap.
150 -> 80 
As per summer sweep up blog https://secure.runescape.com/m=news/summer-sweep-up-2026?oldschool=1