### PR TITLE
Highlight rumour code in fairy ring favourites menu

### DIFF
--- a/src/main/java/com/geel/hunterrumours/FairyRingFavouriteMenuHighlighter.java
+++ b/src/main/java/com/geel/hunterrumours/FairyRingFavouriteMenuHighlighter.java
@@ -1,0 +1,38 @@
+package com.geel.hunterrumours;
+
+import net.runelite.api.Menu;
+import net.runelite.api.MenuEntry;
+import net.runelite.client.util.ColorUtil;
+import net.runelite.client.util.Text;
+
+import java.awt.Color;
+
+final class FairyRingFavouriteMenuHighlighter {
+    private static final String FAVOURITES = "Favourites";
+    private static final Color RUMOUR_COLOR = Color.GREEN;
+
+    private FairyRingFavouriteMenuHighlighter() {
+    }
+
+    static boolean highlight(MenuEntry[] entries, String fairyRingCode) {
+        if (entries == null || fairyRingCode == null || fairyRingCode.length() != 3) {
+            return false;
+        }
+
+        for (MenuEntry entry : entries) {
+            Menu submenu = entry.getSubMenu();
+            if (submenu == null || !FAVOURITES.equals(Text.removeTags(entry.getOption()))) {
+                continue;
+            }
+
+            for (MenuEntry favourite : submenu.getMenuEntries()) {
+                String option = Text.removeTags(favourite.getOption());
+                if (fairyRingCode.equalsIgnoreCase(option)) {
+                    favourite.setOption(ColorUtil.prependColorTag(option, RUMOUR_COLOR));
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
+++ b/src/main/java/com/geel/hunterrumours/HunterRumoursPlugin.java
@@ -219,6 +219,18 @@ public class HunterRumoursPlugin extends Plugin {
     }
 
     @Subscribe
+    public void onBeforeMenuRender(BeforeMenuRender event) {
+        if (!shouldFairyRingAutoJump()) {
+            return;
+        }
+
+        RumourLocation preferredLocation = preferredLocationPreferences.getPreferredLocation(getCurrentRumour());
+        FairyRingFavouriteMenuHighlighter.highlight(
+                client.getMenu().getMenuEntries(),
+                preferredLocation.getFairyRingCode());
+    }
+
+    @Subscribe
     public void onPlayerChanged(PlayerChanged event) {
         // We only care about ourselves
         if (event.getPlayer().getId() != client.getLocalPlayer().getId()) {

--- a/src/test/java/com/geel/hunterrumours/FairyRingFavouriteMenuHighlighterTest.java
+++ b/src/test/java/com/geel/hunterrumours/FairyRingFavouriteMenuHighlighterTest.java
@@ -1,0 +1,51 @@
+package com.geel.hunterrumours;
+
+import net.runelite.api.Menu;
+import net.runelite.api.MenuEntry;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class FairyRingFavouriteMenuHighlighterTest {
+    @Test
+    public void highlightsOnlyMatchingCodeInFavouritesSubmenu() {
+        MenuEntry parent = entry("Favourites", "Fairy ring");
+        MenuEntry matching = entry("DKS", "Fairy ring");
+        when(matching.getOption()).thenReturn("DKS", "<col=00ff00>DKS");
+        MenuEntry other = entry("AKS", "Fairy ring");
+        Menu submenu = mock(Menu.class);
+        when(parent.getSubMenu()).thenReturn(submenu);
+        when(submenu.getMenuEntries()).thenReturn(new MenuEntry[]{matching, other});
+
+        assertTrue(FairyRingFavouriteMenuHighlighter.highlight(new MenuEntry[]{parent}, "DKS"));
+        assertTrue(FairyRingFavouriteMenuHighlighter.highlight(new MenuEntry[]{parent}, "DKS"));
+
+        verify(matching, times(2)).setOption("<col=00ff00>DKS");
+        verify(matching, never()).setTarget(anyString());
+        verify(other, never()).setOption(anyString());
+        verify(parent, never()).setTarget(anyString());
+    }
+
+    @Test
+    public void ignoresMatchingCodeOutsideFavouritesSubmenu() {
+        MenuEntry matching = entry("DKS", "Fairy ring");
+
+        assertFalse(FairyRingFavouriteMenuHighlighter.highlight(new MenuEntry[]{matching}, "DKS"));
+        verify(matching, never()).setOption(anyString());
+        verify(matching, never()).setTarget(anyString());
+    }
+
+    private static MenuEntry entry(String option, String target) {
+        MenuEntry entry = mock(MenuEntry.class);
+        when(entry.getOption()).thenReturn(option);
+        when(entry.getTarget()).thenReturn(target);
+        return entry;
+    }
+}


### PR DESCRIPTION
## Summary

- highlight the preferred fairy ring code for the active rumour in the right-click **Favourites** submenu
- apply the highlight during `BeforeMenuRender`, after the hover submenu has been populated
- colour only the matching three-letter code and leave the `Fairy ring` target unchanged
- use the same eligibility rules as the existing fairy ring interface highlight

## Testing

- added tests for matching only inside the Favourites submenu
- added repeated-render coverage to ensure colour tags do not accumulate
- ran the complete test suite targeting Java 11
- manually verified the right-click hover submenu in RuneLite safe mode with only the development fork loaded